### PR TITLE
ex: depend on this fork, not ancestor

### DIFF
--- a/ex/geoip-demo.go
+++ b/ex/geoip-demo.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/abh/geoip"
+	"github.com/etix/geoip"
 )
 
 func main() {


### PR DESCRIPTION
etix/geoip appears to be a long-lived fork; building the example against
its ancestor doesn't seem ideal.